### PR TITLE
Fix: Deprecated use of last arg. as keyword param

### DIFF
--- a/lib/xhtml_report_generator.rb
+++ b/lib/xhtml_report_generator.rb
@@ -122,7 +122,7 @@ module XhtmlReportGenerator
       #if !str.force_encoding('UTF-8').valid_encoding?
       #  str.encode!('UTF-8', 'ISO-8859-1', {:invalid => :replace, :undef => :replace, :xml => :text})
       #end
-      tmp = str.force_encoding('UTF-8').encode('UTF-8',{:invalid => :replace, :undef => :replace, :replace => "\u2e2e"})
+      tmp = str.force_encoding('UTF-8').encode('UTF-8', :invalid => :replace, :undef => :replace, :replace => "\u2e2e")
       # replace all special control chars as well but keep newline and whitespace "\u2e2e"
       tmp.force_encoding('binary').gsub!(/[\x00-\x07\x0C-\x1F]|\xef\xbf\xbe|\xef\xbf\xbf/n, "\xe2\xb8\xae".force_encoding('binary'))
       return tmp.force_encoding('UTF-8')


### PR DESCRIPTION
As of Ruby 2.7 the use of hashes in the last argument of a method
call has been deprecated and results in a warning.
Since Ruby automatically converts the last argument in a method to
keyword arguments if it's a hash, simply removing the curly braces
of the hash argument will be enough in this case.